### PR TITLE
Fix API for v2 firmware of wLightBoxS

### DIFF
--- a/blebox_uniapi/box.py
+++ b/blebox_uniapi/box.py
@@ -47,14 +47,14 @@ class Box:
             raise UnsupportedBoxResponse(info, f"{location} has no id") from ex
         location = f"Device:{unique_id} at {address}"
 
-        if "type" in info:
+        try:
             type = info["type"]
-        else:
-            raise UnsupportedBoxResponse(info, f"{location} has no type")
+        except KeyError as ex:
+            raise UnsupportedBoxResponse(info, f"{location} has no type") from ex
 
-        if "product" in info:
+        try:
             product = info["product"]
-        else:
+        except KeyError:
             product = type
 
         location = f"{product}:{unique_id} at {address}"

--- a/blebox_uniapi/box.py
+++ b/blebox_uniapi/box.py
@@ -52,11 +52,10 @@ class Box:
         else:
             raise UnsupportedBoxResponse(info, f"{location} has no type")
 
-        # in firmware before 2020 'wLightBoxS' was stored as 'type'
-        # now it's stored as 'product' and 'type' is 'wLightBox'
-        # before a general refactor this is the easiest way to revert back to old logic
-        if "product" in info and info["product"] == "wLightBoxS":
-            type = "wLightBoxS"
+        if "product" in info:
+            product = info["product"]
+        else:
+            product = type
 
         location = f"{type}:{unique_id} at {address}"
 
@@ -92,6 +91,13 @@ class Box:
         if type == "switchBox":
             if level < 20190808:
                 type = "switchBox0"
+
+        # TODO: make wLightBox API support multiple products
+        # in 2020 wLightBoxS API has been deprecated and it started using wLightBox API
+        # current codebase needs a refactor to support multiple product sharing one API
+        # as a temporary workaround we are using 'alias' type wLightBoxS2
+        if type == "wLightBox" and product == "wLightBoxS":
+            type = "wLightBoxS2"
 
         # Here due to circular dependency
         from .products import Products

--- a/blebox_uniapi/box.py
+++ b/blebox_uniapi/box.py
@@ -47,10 +47,12 @@ class Box:
             raise UnsupportedBoxResponse(info, f"{location} has no id") from ex
         location = f"Device:{unique_id} at {address}"
 
-        try:
+        if "product" in info: # product field was added in 2020 firmware 
+            type = info["product"]
+        elif "type" in info:
             type = info["type"]
-        except KeyError as ex:
-            raise UnsupportedBoxResponse(info, f"{location} has no type") from ex
+        else:
+            raise UnsupportedBoxResponse(info, f"{location} has no type")
         location = f"{type}:{unique_id} at {address}"
 
         try:
@@ -358,7 +360,7 @@ class Box:
         if not isinstance(value, str):
             raise BadFieldNotAString(self.name, field, value)
 
-        if len(value) != 8:
+        if len(value) != 2 and len(value) != 8: # in MONO mode only white is given
             raise BadFieldNotRGBW(self.name, field, value)
         return value
 

--- a/blebox_uniapi/box.py
+++ b/blebox_uniapi/box.py
@@ -57,13 +57,13 @@ class Box:
         else:
             product = type
 
-        location = f"{type}:{unique_id} at {address}"
+        location = f"{product}:{unique_id} at {address}"
 
         try:
             name = info["deviceName"]
         except KeyError as ex:
             raise UnsupportedBoxResponse(info, f"{location} has no name") from ex
-        location = f"'{name}' ({type}:{unique_id} at {address})"
+        location = f"'{name}' ({product}:{unique_id} at {address})"
 
         try:
             firmware_version = info["fv"]
@@ -71,7 +71,7 @@ class Box:
             raise UnsupportedBoxResponse(
                 info, f"{location} has no firmware version"
             ) from ex
-        location = f"'{name}' ({type}:{unique_id}/{firmware_version} at {address})"
+        location = f"'{name}' ({product}:{unique_id}/{firmware_version} at {address})"
 
         try:
             hardware_version = info["hv"]
@@ -92,13 +92,6 @@ class Box:
             if level < 20190808:
                 type = "switchBox0"
 
-        # TODO: make wLightBox API support multiple products
-        # in 2020 wLightBoxS API has been deprecated and it started using wLightBox API
-        # current codebase needs a refactor to support multiple product sharing one API
-        # as a temporary workaround we are using 'alias' type wLightBoxS2
-        if type == "wLightBox" and product == "wLightBoxS":
-            type = "wLightBoxS2"
-
         # Here due to circular dependency
         from .products import Products
 
@@ -108,6 +101,14 @@ class Box:
             raise UnsupportedBoxResponse(
                 info, f"{location} is not a supported type"
             ) from ex
+
+        # TODO: make wLightBox API support multiple products
+        # in 2020 wLightBoxS API has been deprecated and it started using wLightBox API
+        # current codebase needs a refactor to support multiple product sharing one API
+        # as a temporary workaround we are using 'alias' type wLightBoxS2
+        if type == "wLightBox" and product == "wLightBoxS":
+            config = Products.CONFIG["types"]["wLightBoxS2"]
+            type = "wLightBoxS"
 
         # Ok to crash here, since it's a bug
         self._data_path = config["api_path"]
@@ -128,6 +129,7 @@ class Box:
         )
 
         self._type = type
+        self._product = product
         self._unique_id = unique_id
         self._name = name
         self._firmware_version = firmware_version
@@ -174,6 +176,10 @@ class Box:
     @property
     def type(self):
         return self._type
+
+    @property
+    def product(self):
+        return self._product
 
     @property
     def unique_id(self):

--- a/blebox_uniapi/products.py
+++ b/blebox_uniapi/products.py
@@ -189,17 +189,17 @@ class Products:
                 ],
             },
             "wLightBoxS": {
-                "api_path": "/api/light/state",
-                "api_level_range": [20180718, 20180718],
+                "api_path": "/api/rgbw/state",
+                "api_level_range": [20200229, 20200229],
                 "api": {
                     "set": lambda x: (
                         "POST",
-                        "/api/light/set",
-                        f'{{"light": {{"desiredColor": "{x}"}}}}',
+                        "/api/rgbw/set",
+                        f'{{"rgbw": {{"desiredColor": "{x}"}}}}',
                     )
                 },
-                "lights": [["brightness", {"desired": "light/desiredColor"}]],
-            },
+                "lights": [["brightness", {"desired": "rgbw/desiredColor"}]],
+            }
         }
     }
 
@@ -235,9 +235,11 @@ class Products:
                 "gateBox": root,
             }
 
-        try:
+        if "product" in info: # product field was added in 2020 firmware
+            product_type = info["product"]
+        elif "type" in info:
             product_type = info["type"]
-        except KeyError:
+        else:
             raise UnsupportedBoxResponse("Missing 'type' field:", info)
 
         try:

--- a/blebox_uniapi/products.py
+++ b/blebox_uniapi/products.py
@@ -141,6 +141,15 @@ class Products:
                 },
                 "switches": [["0.relay", {"state": "relays/[relay=0]/state"}, "relay"]],
             },
+            "switchBoxDC": {
+                "api_path": "/api/relay/state",
+                "api_level_range": [20200831, 20200831],
+                "api": {
+                    "on": lambda x=None: ("GET", "/s/1", None),
+                    "off": lambda x=None: ("GET", "/s/0", None),
+                },
+                "switches": [["0.relay", {"state": "relays/[relay=0]/state"}, "relay"]],
+            },
             "switchBoxD": {
                 "api_path": "/api/relay/state",
                 "api_level_range": [20190808, 20190808],

--- a/blebox_uniapi/products.py
+++ b/blebox_uniapi/products.py
@@ -189,6 +189,18 @@ class Products:
                 ],
             },
             "wLightBoxS": {
+                "api_path": "/api/light/state",
+                "api_level_range": [20180718, 20180718],
+                "api": {
+                    "set": lambda x: (
+                        "POST",
+                        "/api/light/set",
+                        f'{{"light": {{"desiredColor": "{x}"}}}}',
+                    )
+                },
+                "lights": [["brightness", {"desired": "light/desiredColor"}]],
+            },
+            "wLightBoxS2": {
                 "api_path": "/api/rgbw/state",
                 "api_level_range": [20200229, 20200229],
                 "api": {
@@ -239,12 +251,6 @@ class Products:
             product_type = info["type"]
         else:
             raise UnsupportedBoxResponse("Missing 'type' field:", info)
-
-        # in firmware before 2020 'wLightBoxS' was stored as 'type'
-        # now it's stored as 'product' and 'type' is 'wLightBox'
-        # before a general refactor this is the easiest way to revert back to old logic
-        if "product" in info and info["product"] == "wLightBoxS":
-            product_type = "wLightBoxS"
 
         try:
             info = data[product_type]

--- a/blebox_uniapi/products.py
+++ b/blebox_uniapi/products.py
@@ -247,9 +247,9 @@ class Products:
                 "gateBox": root,
             }
 
-        if "type" in info:
+        try:
             product_type = info["type"]
-        else:
+        except KeyError:
             raise UnsupportedBoxResponse("Missing 'type' field:", info)
 
         try:

--- a/blebox_uniapi/products.py
+++ b/blebox_uniapi/products.py
@@ -141,15 +141,6 @@ class Products:
                 },
                 "switches": [["0.relay", {"state": "relays/[relay=0]/state"}, "relay"]],
             },
-            "switchBoxDC": {
-                "api_path": "/api/relay/state",
-                "api_level_range": [20200831, 20200831],
-                "api": {
-                    "on": lambda x=None: ("GET", "/s/1", None),
-                    "off": lambda x=None: ("GET", "/s/0", None),
-                },
-                "switches": [["0.relay", {"state": "relays/[relay=0]/state"}, "relay"]],
-            },
             "switchBoxD": {
                 "api_path": "/api/relay/state",
                 "api_level_range": [20190808, 20190808],
@@ -208,7 +199,7 @@ class Products:
                     )
                 },
                 "lights": [["brightness", {"desired": "rgbw/desiredColor"}]],
-            }
+            },
         }
     }
 
@@ -244,12 +235,16 @@ class Products:
                 "gateBox": root,
             }
 
-        if "product" in info: # product field was added in 2020 firmware
-            product_type = info["product"]
-        elif "type" in info:
+        if "type" in info:
             product_type = info["type"]
         else:
             raise UnsupportedBoxResponse("Missing 'type' field:", info)
+
+        # in firmware before 2020 'wLightBoxS' was stored as 'type'
+        # now it's stored as 'product' and 'type' is 'wLightBox'
+        # before a general refactor this is the easiest way to revert back to old logic
+        if "product" in info and info["product"] == "wLightBoxS":
+            product_type = "wLightBoxS"
 
         try:
             info = data[product_type]

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -350,6 +350,21 @@ class TestWLightBoxS(DefaultBoxTest):
     """
     )
 
+    DEVICE_INFO2 = {
+        "device": {
+            "deviceName": "My wLightBoxS",
+            "type": "wLightBox",
+            "product": "wLightBoxS",
+            "hv": "s_0.1",
+            "fv": "0.1022",
+            "universe": 0,
+            "apiLevel": "20200229",
+            "id": "ce50e32d2707",
+            "ip": "192.168.1.25",
+            "availableFv": None
+        }
+    }
+
     def patch_version(apiLevel):
         """Generate a patch for a JSON state fixture."""
         return f"""
@@ -448,6 +463,15 @@ class TestWLightBoxS(DefaultBoxTest):
         assert entity.device_info["manufacturer"] == "BleBox"
         assert entity.device_info["model"] == "wLightBoxS"
         assert entity.device_info["sw_version"] == "0.924"
+
+    async def test_device_info2(self, aioclient_mock):
+        await self.allow_get_info(aioclient_mock, self.DEVICE_INFO2)
+        entity = (await self.async_entities(aioclient_mock))[0]
+        assert entity.device_info["name"] == "My wLightBoxS"
+        assert entity.device_info["mac"] == "ce50e32d2707"
+        assert entity.device_info["manufacturer"] == "BleBox"
+        assert entity.device_info["model"] == "wLightBoxS"
+        assert entity.device_info["sw_version"] == "0.1022"
 
     async def test_update(self, aioclient_mock):
         """Test light updating."""


### PR DESCRIPTION
# About the issue this PR fixes

After upgrading my wLightBoxS module to latest firmware version, I have noticed that my HomeAssistant instance was no longer able to control it. The same has also been already reported in HomeAssistant repository: https://github.com/home-assistant/core/issues/46847

I've read the API description and it seems that there were some breaking changes introduced which this library would have to handle. The easiest solution I've found (and which is part of this PR) was to bump up the supported firmware version number for wLightBoxS and update the urls and data models accordingly. This will require current users of HA integration to update the firmware of their modules, but this way it didn't require much refactoring of the library. However, in the future the wLightBox and wLightBoxS could be unified as now they have similar API and could be handled in the same way (wLightBoxS is wLightBox in MONO mode).

# API changes
Below are some screenshots of the API from before the firmware upgrade and after:

## GET device info
Note: Current url is depricated but it still works
### v1
![v1-info](https://user-images.githubusercontent.com/3457048/111924351-6c3ae200-8aa4-11eb-9571-20e69c6c1af8.PNG)
### v2
![v2-info](https://user-images.githubusercontent.com/3457048/111924352-6e9d3c00-8aa4-11eb-9332-86a864e87681.PNG)

## GET light state
### v1
![v1-get-light](https://user-images.githubusercontent.com/3457048/111924381-8d033780-8aa4-11eb-96fe-cab1b63a347e.PNG)
### v2
![v2-get-light](https://user-images.githubusercontent.com/3457048/111924384-8f659180-8aa4-11eb-8277-d9a83287bb87.PNG)

## POST light state
### v1
![v1-set-light](https://user-images.githubusercontent.com/3457048/111924391-95f40900-8aa4-11eb-97b2-a846ec5d3584.PNG)
### v2
![v2-set-light](https://user-images.githubusercontent.com/3457048/111924394-97bdcc80-8aa4-11eb-9631-6c60fa40a10e.PNG)