### PR TITLE
gatebox fix, version 1 - with homeasssistant changes needed

### DIFF
--- a/blebox_uniapi/box.py
+++ b/blebox_uniapi/box.py
@@ -110,6 +110,16 @@ class Box:
             config = Products.CONFIG["types"]["wLightBoxS2"]
             type = "wLightBoxS"
 
+        # Currently code doesn't support different apis for the same types or products
+        # and should be heavily refactored to support that functionality.
+        # Also I don't know if every "gateBox" product have apiLevel (line 86) that is
+        # why I used additional condition
+        if type == "gateBox" and level:
+            _min, _max = Products.CONFIG["types"]["gateBoxB"]["api_level_range"]
+            if _min <= level <= _max:
+                config = Products.CONFIG["types"]["gateBoxB"]
+                type = "gateBoxB"
+
         # Ok to crash here, since it's a bug
         self._data_path = config["api_path"]
         min_supported, max_supported = config["api_level_range"]

--- a/blebox_uniapi/box.py
+++ b/blebox_uniapi/box.py
@@ -112,8 +112,6 @@ class Box:
 
         # Currently code doesn't support different apis for the same types or products
         # and should be heavily refactored to support that functionality.
-        # Also I don't know if every "gateBox" product have apiLevel (line 86) that is
-        # why I used additional condition
         if type == "gateBox" and level:
             _min, _max = Products.CONFIG["types"]["gateBoxB"]["api_level_range"]
             if _min <= level <= _max:

--- a/blebox_uniapi/cover.py
+++ b/blebox_uniapi/cover.py
@@ -3,7 +3,7 @@ from .feature import Feature
 
 
 class Gate:
-    """Previous class name: Slider, is it problem if I renamed it ?"""
+
     def read_state(self, alias, raw_value, product):
         raw = raw_value("state")
         return product.expect_int(alias, raw, 4, 0)

--- a/blebox_uniapi/feature.py
+++ b/blebox_uniapi/feature.py
@@ -25,7 +25,7 @@ class Feature:
 
     @property
     def product(self):
-       return self._product
+        return self._product
 
     # TODO: (cleanup) move to product/box ?
     def raw_value(self, name):

--- a/blebox_uniapi/products.py
+++ b/blebox_uniapi/products.py
@@ -55,8 +55,6 @@ class Products:
                     ]
                 ],
             },
-            # I don't know well naming convention for your products and it's subgroups
-            # so I named it temporary "gateBoxB".
             "gateBoxB": {
                 "api_path": "/state",
                 "api_level_range": [20200831, 20210118],

--- a/blebox_uniapi/products.py
+++ b/blebox_uniapi/products.py
@@ -55,6 +55,25 @@ class Products:
                     ]
                 ],
             },
+            # I don't know well naming convention for your products and it's subgroups
+            # so I named it temporary "gateBoxB".
+            "gateBoxB": {
+                "api_path": "/state",
+                "api_level_range": [20200831, 20210118],
+                "api": {
+                    "primary": lambda x=None: ("GET", "/s/p", None),
+                    "secondary": lambda x=None: ("GET", "/s/s", None),
+                },
+                "covers": [
+                    [
+                        "position",
+                        {
+                            "position": "gate/currentPos",
+                        },
+                        "gateboxb",
+                    ]
+                ],
+            },
             "gateController": {
                 "api_path": "/api/gatecontroller/state",
                 "api_level_range": [20180604, 20190911],

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -22,6 +22,11 @@ SUPPORT_SET_POSITION = 4
 SUPPORT_STOP = 8
 
 
+def patch_version(apiLevel):
+    """Helper function for generate a patch for a JSON state fixture."""
+    return f"""{{ "device": {{ "apiLevel": {apiLevel} }} }}"""
+
+
 class BleBoxCoverEntity(CommonEntity):
     """Representation of a BleBox cover feature."""
 
@@ -50,6 +55,7 @@ class BleBoxCoverEntity(CommonEntity):
         types = {
             "shutter": DEVICE_CLASS_SHUTTER,
             "gatebox": DEVICE_CLASS_DOOR,
+            "gateboxb": DEVICE_CLASS_DOOR,
             "gate": DEVICE_CLASS_DOOR,
         }
         return types[self._feature.device_class]
@@ -154,10 +160,6 @@ class TestShutter(CoverTest):
     }
     """
     )
-
-    def patch_version(apiLevel):
-        """Generate a patch for a JSON state fixture."""
-        return f"""{{ "device": {{ "apiLevel": {apiLevel} }} }}"""
 
     DEVICE_INFO_FUTURE = jmerge(DEVICE_INFO, patch_version(20190912))
     DEVICE_INFO_LATEST = jmerge(DEVICE_INFO, patch_version(20190911))
@@ -469,6 +471,104 @@ class TestGateBox(CoverTest):
             await entity.async_set_cover_position(**{ATTR_POSITION: 1})  # almost closed
 
 
+class TestGateBoxB(CoverTest):
+    """Tests for cover devices representing a BleBox gateBoxB subgroup."""
+
+    DEV_INFO_PATH = "state"
+
+    DEVICE_INFO = json.loads(
+        """
+        {
+            "device": {
+                "deviceName":"My gateBox 1",
+                "type":"gateBox",
+                "product":"gateBox",
+                "hv":"9.1d",
+                "fv":"0.1010",
+                "universe":0,
+                "apiLevel":"20200831",
+                "id":"1afe34d27e4f",
+                "ip":"192.168.4.1",
+                "availableFv":null
+            }
+        }
+        """
+    )
+
+    DEVICE_INFO_FUTURE = jmerge(DEVICE_INFO, patch_version(20210200))
+    DEVICE_INFO_LATEST = jmerge(DEVICE_INFO, patch_version(20210118))
+
+    DEVICE_INFO_OUTDATED = DEVICE_INFO
+    DEVICE_INFO_MINIMUM = DEVICE_INFO
+    DEVICE_INFO_UNSUPPORTED = DEVICE_INFO
+
+    DEVICE_INFO_UNSPECIFIED_API = None  # already handled as default case
+
+    STATE_DEFAULT = json.loads(
+        """
+        {
+            "gate": {"currentPos": 0}
+        }
+        """
+    )
+
+    STATE_CLOSED = STATE_DEFAULT
+    STATE_STOPPED = jmerge(STATE_DEFAULT, '{"gate": {"currentPos": 50 }}')
+    STATE_FULLY_OPENED = jmerge(STATE_DEFAULT, '{"gate": {"currentPos": 100 }}')
+
+    async def test_unsupported_version(self, aioclient_mock):
+        """
+        Test version support. We don't need this - why is it written like that ?
+        What is the connection between api_level of the product and it's api_level_range ?
+        If api_level won't be in range of api_level_range then it will be using gateBox
+        class, not gateBoxB class.
+        """
+
+    async def test_init(self, aioclient_mock):
+        """Test cover default state."""
+
+        await self.allow_get_info(aioclient_mock)
+        entity = (await self.async_entities(aioclient_mock))[0]
+
+        assert entity.name == "My gateBox 1 (gateBoxB#position)"
+        assert entity.unique_id == "BleBox-gateBoxB-1afe34d27e4f-position"
+        assert entity.device_class == DEVICE_CLASS_DOOR
+        assert entity.supported_features & SUPPORT_OPEN
+        assert entity.supported_features & SUPPORT_CLOSE
+        assert entity.current_cover_position is None
+        self.assert_state(entity, None)
+
+    async def test_device_info(self, aioclient_mock):
+        """Test device info state."""
+
+        await self.allow_get_info(aioclient_mock, self.DEVICE_INFO)
+        entity = (await self.async_entities(aioclient_mock))[0]
+
+        assert entity.device_info["name"] == "My gateBox 1"
+        assert entity.device_info["mac"] == "1afe34d27e4f"
+        assert entity.device_info["manufacturer"] == "BleBox"
+        assert entity.device_info["model"] == "gateBoxB"
+        assert entity.device_info["sw_version"] == "0.1010"
+
+    async def test_fully_opened(self, aioclient_mock):
+        """Test cover fully opened."""
+
+        entity = await self.updated(aioclient_mock, self.STATE_FULLY_OPENED)
+        assert entity.state == STATE_OPEN
+
+    async def test_stop(self, aioclient_mock):
+        """Test cover stopped."""
+
+        entity = await self.updated(aioclient_mock, self.STATE_STOPPED)
+        self.assert_state(entity, STATE_OPEN)
+
+    async def test_closed(self, aioclient_mock):
+        """Test cover closed."""
+
+        entity = await self.updated(aioclient_mock, self.STATE_CLOSED)
+        self.assert_state(entity, STATE_CLOSED)
+
+
 class TestGateController(CoverTest):
     """Tests for cover devices representing a BleBox gateController."""
 
@@ -489,12 +589,6 @@ class TestGateController(CoverTest):
     }
     """
     )
-
-    def patch_version(apiLevel):
-        """Generate a patch for a JSON state fixture."""
-        return f"""
-        {{ "device": {{ "apiLevel": {apiLevel} }} }}
-        """
 
     DEVICE_INFO_FUTURE = jmerge(DEVICE_INFO, patch_version(20190912))
     DEVICE_INFO_LATEST = jmerge(DEVICE_INFO, patch_version(20190911))


### PR DESCRIPTION
1. This solution require one additional line of code in homeassistant/components/blebox/const.py but I think it's cleaner that version 2, however version 2 don't require any changes in homeassistant package, but it's more obscure and ugly.

Code that is require in homeassistant/components/blebox/const.py:
```py
BLEBOX_TO_HASS_DEVICE_CLASSES = {
    "shutter": DEVICE_CLASS_SHUTTER,
    "gatebox": DEVICE_CLASS_DOOR,
    "gateboxb": DEVICE_CLASS_DOOR, <-- needed line
    "gate": DEVICE_CLASS_GATE,
    "relay": DEVICE_CLASS_SWITCH,
    "temperature": DEVICE_CLASS_TEMPERATURE,
}
```
2. I left in code comments, additional notes and questions.
3. The main idea for this changes was to avoid or minimize modifications in Feature, and Cover class(or other common classes), and focused on changing GateBox class.
