### PR TITLE
Add thermoBox and multisensor (tempSensor Pro) support

### DIFF
--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -167,7 +167,7 @@ BOX_TYPE_CONF = {
             ],
         }
     },
-    # thermoboxBox
+    # thermoBox
     "thermoBox": {
         20180604: {
             # TODO: read extended state only once on startup

--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -269,7 +269,7 @@ BOX_TYPE_CONF = {
     # multiSensor (tempSensor Pro)
     "multiSensor": {
         20180604: {
-            "api_path": "/api/multiensor/state",
+            "api_path": "/api/multisensor/state",
             "sensors": [
                 [
                     "0.temperature",

--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -167,6 +167,31 @@ BOX_TYPE_CONF = {
             ],
         }
     },
+    # thermoboxBox
+    "thermoBox": {
+        20180604: {
+            # TODO: read extended state only once on startup
+            "api_path": "/api/thermo/extended/state",
+            # TODO: use an api map (map to semver)? Or constraints?
+            "api": {
+                "on": lambda x=None: ("GET", "/s/1", None),
+                "off": lambda x=None: ("GET", "/s/0", None),
+                "set": lambda x=None: ("GET", "/s/t/" + str(x), None),
+            },
+            "climates": [
+                [
+                    "thermostat",
+                    {
+                        "desired": "thermo/desiredTemp",
+                        "minimum": "thermo/minimumTemp",
+                        "maximum": "thermo/maximumTemp",
+                        "temperature": "sensors/[id=0]/value",
+                        "state": "thermo/state",
+                    },
+                ]
+            ],
+        }
+    },
     "shutterBox": {
         20180604: {
             # name of the subclass class of shutter family

--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -266,6 +266,50 @@ BOX_TYPE_CONF = {
             ],
         }
     },
+    # multiSensor (tempSensor Pro)
+    "multiSensor": {
+        20180604: {
+            "api_path": "/api/multiensor/state",
+            "sensors": [
+                [
+                    "0.temperature",
+                    {
+                        "temperature": "multiSensor/sensors/[id=0]/value",
+                        "trend": "multiSensor/sensors/[id=0]/trend",
+                        "state": "multiSensor/sensors/[id=0]/state",
+                        "elapsed": "multiSensor/sensors/[id=0]/elapsedTimeS",
+                    },
+                ],
+                [
+                    "1.temperature",
+                    {
+                        "temperature": "multiSensor/sensors/[id=1]/value",
+                        "trend": "multiSensor/sensors/[id=1]/trend",
+                        "state": "multiSensor/sensors/[id=1]/state",
+                        "elapsed": "multiSensor/sensors/[id=1]/elapsedTimeS",
+                    },
+                ],
+                [
+                    "2.temperature",
+                    {
+                        "temperature": "multiSensor/sensors/[id=2]/value",
+                        "trend": "multiSensor/sensors/[id=2]/trend",
+                        "state": "multiSensor/sensors/[id=2]/state",
+                        "elapsed": "multiSensor/sensors/[id=2]/elapsedTimeS",
+                    },
+                ],
+                [
+                    "3.temperature",
+                    {
+                        "temperature": "multiSensor/sensors/[id=3]/value",
+                        "trend": "multiSensor/sensors/[id=3]/trend",
+                        "state": "multiSensor/sensors/[id=3]/state",
+                        "elapsed": "multiSensor/sensors/[id=3]/elapsedTimeS",
+                    },
+                ]
+            ],
+        }
+    },
     # wLightBox
     "wLightBox": {
         20180718: {


### PR DESCRIPTION
I tested this integration on blebox_uniapi available in HomeAssistant sources which one is not include latest commit from blebox/blebox_uniapi
https://github.com/blebox/blebox_uniapi/commit/059f0c7c08f5501c179bdf7f3875294c2360ab9d

(i modified products.py file)


>bash-5.1# diff -Nuar products.py products.py
--- products.py
+++ products.py
@@ -118,6 +118,29 @@
            "thermoBox": {
                # TODO: read extended state only once on startup
                "api_path": "/api/thermo/extended/state",
                # TODO: use an api map (map to semver)? Or constraints?
                "api_level_range": [20180604, 20200229],
                "api": {
                    "on": lambda x=None: ("GET", "/s/1", None),
                    "off": lambda x=None: ("GET", "/s/0", None),
                    "set": lambda x=None: ("GET", "/s/t/" + str(x), None),
                },
                "climates": [
                    [
                        "thermostat",
                        {
                            "desired": "thermo/desiredTemp",
                            "minimum": "thermo/minimumTemp",
                            "maximum": "thermo/maximumTemp",
                            "temperature": "sensors/[id=0]/value",
                            "state": "thermo/state",
                        },
                    ]
                ],
            },
@@ -250,6 +273,7 @@
                 "saunaBox": info,
                 "thermoBox": info,
                 "switchBoxD": info,


and all works fine (tested on Home Assistant 2021.12.10). Based on it i made this pull request which should works.

Best Regards
![Przechwytywanie2](https://user-images.githubusercontent.com/9624725/150801127-0180d9e8-9129-4cf3-ba81-814cf5fd3612.JPG)
![Przechwytywanie](https://user-images.githubusercontent.com/9624725/150801132-22f25ea4-1448-41b7-ab5a-92b69eeaa1b6.JPG)
.