### PR TITLE
add support for flood sensing for multisensors as binary moisture sensor

### DIFF
--- a/blebox_uniapi/binary_sensor.py
+++ b/blebox_uniapi/binary_sensor.py
@@ -13,17 +13,26 @@ class BinarySensor(Feature):
     def many_from_config(
         cls, product, box_type_config, extended_state
     ) -> list["Feature"]:
+        type_class_map = {
+            "rain": Rain,
+            "flood": Flood,
+        }
+
         output_list = list()
         sensors_list = extended_state.get("multiSensor").get("sensors", {})
         alias, methods = box_type_config[0]
+
         for sensor in sensors_list:
             sensor_type = sensor.get("type")
             sensor_id = sensor.get("id")
-            if sensor.get("type") in ("rain", "flood"):
+
+            if sensor_type in type_class_map:
+                klass = type_class_map[sensor_type]
+
                 if methods.get(sensor_type) is not None:
                     value_method = {sensor_type: methods[sensor_type](sensor_id)}
                     output_list.append(
-                        Rain(
+                        klass(
                             product=product,
                             alias=sensor_type + "_" + str(sensor_id),
                             methods=value_method,
@@ -56,3 +65,29 @@ class Rain(BinarySensor):
 
     def after_update(self) -> None:
         self._current = self._read_rain("rain")
+
+
+class Flood(BinarySensor):
+    def __init__(self, product: "Box", alias: str, methods: dict):
+        self._device_class = "moisture"
+        super().__init__(product, alias, methods)
+
+    @property
+    def state(self) -> bool:
+        return self._current > 0
+
+    @property
+    def device_class(self) -> str:
+        return self._device_class
+
+    def _read_flood(self, field: str) -> Union[float, int, None]:
+        product = self._product
+
+        if product.last_data is not None:
+            raw = self.raw_value(field)
+            if raw is not None:  # no reading
+                return self.raw_value("flood")
+        return 0
+
+    def after_update(self) -> None:
+        self._current = self._read_flood("flood")

--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -610,6 +610,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     "multiSensor",
                     {
                         "rain": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                        "flood": lambda x: f"multiSensor/sensors/[id={x}]/value",
                     },
                 ]
             ],
@@ -631,6 +632,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     "multiSensor",
                     {
                         "rain": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                        "flood": lambda x: f"multiSensor/sensors/[id={x}]/value",
                     },
                 ]
             ],


### PR DESCRIPTION
Support for floodsensor via multisensor api. Previously flood reading was misinterpreted as rain causing empty entity in homeassistant.

Visual result of integrating in homeassistant:

![Zrzut ekranu 2024-02-7 o 00 41 49](https://github.com/blebox/blebox_uniapi/assets/1258054/247974b1-5f2d-4b05-9120-e7aec143e979)

![Zrzut ekranu 2024-02-7 o 00 41 56](https://github.com/blebox/blebox_uniapi/assets/1258054/d2b909e5-681e-490e-99f5-ea22b0f16a4c)
