### PR TITLE
gatebox and shutterbox improvements:

### DIFF
--- a/blebox_uniapi/box.py
+++ b/blebox_uniapi/box.py
@@ -117,15 +117,10 @@ class Box:
         self._firmware_version = firmware_version
         self._hardware_version = hardware_version
         self._api_version = level
-
         self._model = config.get("model", type)
-
         self._api = config.get("api", {})
-
         self._features = self.create_features(config, info, extended_state)
-
         self._config = config
-
         self._update_last_data(extended_state)
 
     def create_features(

--- a/blebox_uniapi/box.py
+++ b/blebox_uniapi/box.py
@@ -126,7 +126,7 @@ class Box:
 
         self._config = config
 
-        self._update_last_data(None)
+        self._update_last_data(extended_state)
 
     def create_features(
         self, config: dict, info: dict, extended_state: Optional[dict]

--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -121,7 +121,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
             ],
         },
         20200831: {
-            "api_path": "/state",
+            "api_path": "/state/extended",
             "extended_state_path": "/state/extended",
             "api": {
                 "primary": lambda x=None: ("GET", "/s/p", None),
@@ -132,6 +132,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     "position",
                     {
                         "position": "gate/currentPos",
+                        "gate_type": "gate/gateType",
                     },
                     "gatebox",
                     GateBoxB,

--- a/blebox_uniapi/cover.py
+++ b/blebox_uniapi/cover.py
@@ -112,7 +112,7 @@ class Gate:
     def read_cover_type(
         self, alias: str, raw_value: Any, product: "Box"
     ) -> UnifiedCoverType:
-        return raw_value("gateType", UnifiedCoverType.DOOR)
+        return UnifiedCoverType.GATE
 
     @property
     def min_position(self) -> int:

--- a/blebox_uniapi/cover.py
+++ b/blebox_uniapi/cover.py
@@ -1,4 +1,4 @@
-from enum import IntEnum
+from enum import IntEnum, auto
 
 import blebox_uniapi.error
 from .error import MisconfiguredDevice
@@ -10,6 +10,14 @@ if TYPE_CHECKING:
 
 
 class BleboxCoverState(IntEnum):
+    """BleboxCoverState defines possible states of cover devices.
+
+    Note that enumeration of states is partially shared between
+    different types of devices (shutterBox, gateController) but
+    not all states are possible for every type. For details of
+    states refer to blebox official API documentation.
+    """
+
     MOVING_DOWN = 0
     MOVING_UP = 1
     MANUALLY_STOPPED = 2
@@ -21,8 +29,68 @@ class BleboxCoverState(IntEnum):
     SAFETY_STOP = 8
 
 
+class ShutterBoxControlType(IntEnum):
+    """ShutterBoxControlType defines shuterBox command semantics"""
+
+    SEGMENTED_SHUTTER = 1
+    NO_CALIBRATION = 2
+    TILT_SHUTTER = 3
+    WINDOW_OPENER = 4
+    MATERIAL_SHUTTER = 5
+    AWNING = 6
+    SCREEN = 7
+    CURTAIN = 8
+
+
+class GateBoxControlType(IntEnum):
+    """GateBoxControlType defines gateBox command semantics known as `openCloseMode`.
+
+    Control type affects mainly [o]pen, [c]lose, and [n]ext commands which
+    are wrappers around [p]rimary and [s]econdary outputs. The only exception
+    is OPEN_CLOSE (2) control type that also means that the gateBox lacks
+    stop action because typical stop output is wired to [c]lose/[s]econdary
+    command.
+    """
+
+    STEP_BY_STEP = 0
+    ONLY_OPEN = 1
+    OPEN_CLOSE = 2
+
+
+class GateBoxGateType(IntEnum):
+    """GateBoxGateType defines possible gate/cover types reported by gateBox"""
+
+    SLIDING_DOOR = 0
+    GARAGE_DOOR = 1
+    OVER_DOOR = 2
+    DOOR = 3
+
+
+class UnifiedCoverType(IntEnum):
+    """UnifiedCoverType defines single "cover type" concept shared between different
+    devices.
+
+    Some device types have concept of control type/mode that affects how device
+    operates and how it is being used (e.g. control type in shutterBox/gateControler),
+    but others have these two concepts separated (e.g. open mode vs. gate type in
+    gateBox). This enum provides unified concept of controlled cover type that
+    can be infered from internal device information end exposed to library user.
+
+    """
+    AWNING = auto()
+    BLIND = auto()
+    CURTAIN = auto()
+    DAMPER = auto()
+    DOOR = auto()
+    GARAGE = auto()
+    GATE = auto()
+    SHADE = auto()
+    SHUTTER = auto()
+    WINDOW = auto()
+
+
 class Gate:
-    _control_type: int
+    _control_type: Optional[int]
 
     def __init__(self, control_type: int):
         self._control_type = control_type
@@ -40,6 +108,11 @@ class Gate:
         raw = raw_value("tilt")
         min_position = self.min_position
         return product.expect_int(alias, raw, 100, min_position)
+
+    def read_cover_type(
+        self, alias: str, raw_value: Any, product: "Box"
+    ) -> UnifiedCoverType:
+        return raw_value("gateType", UnifiedCoverType.DOOR)
 
     @property
     def min_position(self) -> int:
@@ -69,18 +142,40 @@ class Gate:
 
 
 class Shutter(Gate):
+    _control_type: Optional[ShutterBoxControlType]
+
     @property
     def min_position(self) -> int:
         return -1  # "unknown"
 
     @property
     def has_tilt(self) -> bool:
-        if self._control_type == 3:
-            return True
-        return False
+        return self._control_type == ShutterBoxControlType.TILT_SHUTTER
+
+    def read_cover_type(
+        self, alias: str, raw_value: Any, product: "Box"
+    ) -> UnifiedCoverType:
+        if self._control_type == ShutterBoxControlType.SEGMENTED_SHUTTER:
+            return UnifiedCoverType.SHUTTER
+        if self._control_type == ShutterBoxControlType.NO_CALIBRATION:
+            return UnifiedCoverType.SHUTTER
+        if self._control_type == ShutterBoxControlType.TILT_SHUTTER:
+            return UnifiedCoverType.SHUTTER
+        if self._control_type == ShutterBoxControlType.WINDOW_OPENER:
+            return UnifiedCoverType.WINDOW
+        if self._control_type == ShutterBoxControlType.MATERIAL_SHUTTER:
+            return UnifiedCoverType.SHADE
+        if self._control_type == ShutterBoxControlType.AWNING:
+            return UnifiedCoverType.AWNING
+        if self._control_type == ShutterBoxControlType.SCREEN:
+            return UnifiedCoverType.SHADE
+        if self._control_type == ShutterBoxControlType.CURTAIN:
+            return UnifiedCoverType.CURTAIN
 
 
 class GateBox(Gate):
+    _control_type: Optional[GateBoxControlType]
+
     @property
     def is_slider(self) -> bool:
         return False
@@ -150,14 +245,29 @@ class GateBoxB(GateBox):
         return 4  # open (upper/right limit)
 
     def read_desired(self, alias: str, raw_value: Any, product: "Box") -> Optional[int]:
-        return None
+        return raw_value("position")
 
     def read_has_stop(self, alias: str, raw_value: Any, product: "Box") -> bool:
-        """
-        "extraButtonType" field isn't available in responses
-        from "GET" posts to "/s/p" or "/s/s" so I just returned True
-        """
-        return True
+        # note: if control type is unknown we assume it is not open/close
+        #       and has the stop feature via secondary button command.
+        return self._control_type != GateBoxControlType.OPEN_CLOSE
+
+    def read_cover_type(
+        self, alias: str, raw_value: Any, product: "Box"
+    ) -> Optional[UnifiedCoverType]:
+        if (gate_type := raw_value("gate_type")) is None:
+            return
+
+        if gate_type == GateBoxGateType.GARAGE_DOOR:
+            return UnifiedCoverType.GARAGE
+        if gate_type == GateBoxGateType.SLIDING_DOOR:
+            return UnifiedCoverType.GATE
+        return UnifiedCoverType.DOOR
+
+    @property
+    def close_command(self) -> str:
+        if self._control_type == GateBoxControlType.OPEN_CLOSE:
+            return "secondary"
 
 
 GateT = TypeVar("GateT", bound=Gate)
@@ -165,6 +275,11 @@ GateT = TypeVar("GateT", bound=Gate)
 
 # TODO: handle tilt
 class Cover(Feature):
+    _desired: Optional[int]
+    _state: Optional[BleboxCoverState]
+    _has_stop: Optional[bool]
+    _cover_type: Optional[UnifiedCoverType]
+
     def __init__(
         self,
         product: "Box",
@@ -174,14 +289,14 @@ class Cover(Feature):
         subclass: Type[GateT],
         extended_state: dict,
     ) -> None:
-        self._control_type = None
-        if extended_state not in [None, {}]:
-            self._control_type = extended_state.get("shutter", {}).get(
-                "controlType", {}
-            )
+        control_type = None
+        if extended_state and issubclass(subclass, Shutter):
+            control_type = extended_state.get("shutter", {}).get("controlType", None)
+        elif extended_state and issubclass(subclass, GateBoxB):
+            control_type = extended_state.get("gate", {}).get("openCloseMode", None)
 
         self._device_class = dev_class
-        self._attributes: GateT = subclass(self._control_type)
+        self._attributes: GateT = subclass(control_type)
         self._tilt_current = None
         super().__init__(product, alias, methods)
 
@@ -215,6 +330,10 @@ class Cover(Feature):
     def has_stop(self) -> bool:
         return self._has_stop
 
+    @property
+    def cover_type(self) -> Optional[UnifiedCoverType]:
+        return self._cover_type
+
     async def async_open(self) -> None:
         await self.async_api_command(self._attributes.open_command)
 
@@ -231,7 +350,7 @@ class Cover(Feature):
         await self.async_api_command("position", value)
 
     async def async_set_tilt_position(self, value: Any) -> None:
-        if self.has_tilt and self._control_type == 3:
+        if self.has_tilt:
             await self.async_api_command("tilt", value)
         else:
             raise NotImplementedError
@@ -241,6 +360,14 @@ class Cover(Feature):
 
     async def async_open_tilt(self, **kwargs: Any) -> None:
         await self.async_api_command("tilt", 0)
+
+    def _read_cover_type(self) -> Optional[UnifiedCoverType]:
+        product = self._product
+        if not product.last_data:
+            return None
+
+        alias = self._alias
+        return self._attributes.read_cover_type(alias, self.raw_value, self._product)
 
     def _read_desired(self) -> Any:
         product = self._product
@@ -276,5 +403,7 @@ class Cover(Feature):
         self._desired = self._read_desired()
         self._state = self._read_state()
         self._has_stop = self._read_has_stop()
-        if self._control_type == 3 and self._attributes.has_tilt:
+        self._cover_type = self._read_cover_type()
+
+        if self._attributes.has_tilt:
             self._tilt_current = self._read_tilt()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,11 +154,14 @@ class DefaultBoxTest:
         json_get_expect(
             aioclient_mock, f"http://{self.IP}:80/api/device/state", json=data
         )
-        if hasattr(self, "DEVICE_EXTENDED_INFO"):
-            data = self.DEVICE_EXTENDED_INFO if info is None else info
+        if (
+            (hasattr(self, "DEVICE_EXTENDED_INFO")) and
+            (path := getattr(self, "DEVICE_EXTENDED_INFO_PATH"))
+        ):
+            data = self.DEVICE_EXTENDED_INFO or info
             json_get_expect(
                 aioclient_mock,
-                f"http://{self.IP}:80{self.DEVICE_EXTENDED_INFO_PATH}",
+            f"http://{self.IP}:80/{path.lstrip('/')}",
                 json=data,
             )
 

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -480,7 +480,7 @@ class TestGateBox(CoverTest):
 class TestGateBoxB(CoverTest):
     """Tests for cover devices representing a BleBox gateBoxB subgroup."""
 
-    DEV_INFO_PATH = "state"
+    DEV_INFO_PATH = "state/extended"
 
     DEVICE_INFO = json.loads(
         """
@@ -512,7 +512,17 @@ class TestGateBoxB(CoverTest):
     STATE_DEFAULT = json.loads(
         """
         {
-            "gate": {"currentPos": 0}
+            "gate": {
+                "currentPos": 0,
+                "openCloseMode": 0,
+                "gateType": 1,
+                "gatePulseTimeMs": 1500,
+                "gateOutputState": 0,
+                "extraButtonType": 1,
+                "extraButtonPulseTimeMs": 1500,
+                "extraButtonOutputState": 0,
+                "inputsType": 0
+            }
         }
         """
     )
@@ -524,7 +534,17 @@ class TestGateBoxB(CoverTest):
     STATE_UNKNOWN = json.loads(
         """
         {
-            "gate": {"currentPos": -1}
+            "gate": {
+                "currentPos": -1,
+                "openCloseMode": 0,
+                "gateType": 1,
+                "gatePulseTimeMs": 1500,
+                "gateOutputState": 0,
+                "extraButtonType": 1,
+                "extraButtonPulseTimeMs": 1500,
+                "extraButtonOutputState": 0,
+                "inputsType": 0
+            }
         }
         """
     )

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -444,7 +444,7 @@ class TestWLightBoxS(DefaultBoxTest):
     DEVICE_EXTENDED_INFO = {
         "rgbw": {
             "desiredColor": "f5",
-            "currentColor": "f5",
+            "currentColor": "f5",  # 245 in decimal
             "lastOnColor": "f5",
             "durationsMs": {"colorFade": 1000, "effectFade": 1000, "effectStep": 1000},
             "effectID": 0,
@@ -542,9 +542,8 @@ class TestWLightBoxS(DefaultBoxTest):
 
         assert entity.name == "My wLightBoxS (wLightBoxS#brightness_mono1)"
         assert entity.unique_id == "BleBox-wLightBoxS-1afe34e750b8-brightness_mono1"
-        assert entity.brightness is None
-
-        assert entity.is_on is None
+        assert entity.brightness == 0xf5
+        assert entity.is_on
 
     async def test_device_info(self, aioclient_mock):
         await self.allow_get_info(aioclient_mock, self.DEVICE_INFO)
@@ -863,16 +862,12 @@ class TestWLightBox(DefaultBoxTest):
         assert entity.name == "My light 1 (wLightBox#color_RGBorW)"
         assert entity.unique_id == "BleBox-wLightBox-1afe34e750b8-color_RGBorW"
         # In current state of master branch white_value is not property of BleBoxLightEntity, fake test... dissapointing
-        # assert entity.supported_features & SUPPORT_WHITE_VALUE
-        # assert entity.white_value is None
+        assert entity._feature.supports_white
+        assert entity._feature.white_value == 0x3A
 
-        # assert entity.supported_features & SUPPORT_COLOR
-        # assert entity.hs_color is None
-        # assert entity.white_value is None
-
-        # assert entity.supported_features & SUPPORT_BRIGHTNESS
-        # assert entity.brightness == 123
-        assert entity.is_on is None
+        assert entity._feature.supports_color
+        assert entity.brightness == 0xFA
+        assert entity.is_on is True
 
     async def test_device_info(self, aioclient_mock):
         await self.allow_get_info(aioclient_mock, self.DEVICE_INFO)


### PR DESCRIPTION
* reporting gatebox position (if available)
* fix for open/close mode in gatebox
* foundation for reporting unified cover type across devices
* save initialization state data as last updated
* introduce enums that will allow to map to homeassistant cover types
* simplify tilts

First two improvements will be visible in home assistant once library is updated. 

Examples:
![Zrzut ekranu 2024-02-27 o 20 42 42](https://github.com/blebox/blebox_uniapi/assets/1258054/5e9504c9-9992-4055-970d-32307ee72114)
![Zrzut ekranu 2024-02-27 o 20 42 37](https://github.com/blebox/blebox_uniapi/assets/1258054/e0fdbc7a-c844-4f21-8a49-8077f6a953a9)

Note that gatebox running in open/close mode does not have stop action. This is intended as secondary button action in this case is supposed to be wired to close output of actual gate. Also, for this mode close action incorrectly used `[p]rimary` command instead of `[s]econdary`. In such a case the only way to close the gate was to use "stop" action.

Extra improvements will allow to correctly map gateBox, gateController, and shutterBox control types / open-close modes to types of cover device classes used in home assistant. However, this will require submitting small PR on the home-assistant side.