### PR TITLE
BleBox Multisensor Illuminance Integration

### DIFF
--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -121,7 +121,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
             ],
         },
         20200831: {
-            "api_path": "/state/extended",
+            "api_path": "/state",
             "extended_state_path": "/state/extended",
             "api": {
                 "primary": lambda x=None: ("GET", "/s/p", None),
@@ -132,7 +132,6 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     "position",
                     {
                         "position": "gate/currentPos",
-                        "gate_type": "gate/gateType",
                     },
                     "gatebox",
                     GateBoxB,
@@ -593,6 +592,30 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
         },
     },
     "multiSensor": {
+        20220114: {
+            "api_path": "/state",
+            "extended_state_path": "/state/extended",
+            "sensors": [
+                [
+                    "multiSensor",
+                    {
+                        "illuminance": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                        "temperature": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                        "wind": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                        "humidity": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                    },
+                ]
+            ],
+            "binary_sensors": [
+                [
+                    "multiSensor",
+                    {
+                        "rain": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                        "flood": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                    },
+                ]
+            ],
+        },
         20210413: {
             "api_path": "/state",
             "extended_state_path": "/state/extended",

--- a/blebox_uniapi/sensor.py
+++ b/blebox_uniapi/sensor.py
@@ -31,6 +31,26 @@ class BaseSensor(Feature):
         raise NotImplementedError("Please use SensorFactory")
 
 
+class Illuminance(BaseSensor):
+    def __init__(self, product: "Box", alias: str, methods: dict):
+        super().__init__(product, alias, methods)
+        self._unit = "lx"
+        self._device_class = "illuminance"
+
+    def _read_illuminance(self):
+        product = self._product
+        if product.last_data is not None:
+            raw = self.raw_value("illuminance")
+            if raw is not None:
+                alias = self._alias
+                return round(product.expect_int(alias, raw, 10000000, 0) / 100.0, 1)
+                # 100000, 0 is a representation of illuminance range in lx in mili (it should be devided by 100 like temprature)
+        return None
+
+    def after_update(self) -> None:
+        self._native_value = self._read_illuminance()
+
+
 class Temperature(BaseSensor):
     _current: Union[float, int, None]
 
@@ -93,6 +113,7 @@ class Humidity(BaseSensor):
             if raw is not None:
                 alias = self._alias
                 return round(product.expect_int(alias, raw, 10000, 0) / 100.0, 1)
+
         return None
 
     def after_update(self) -> None:
@@ -162,6 +183,7 @@ class SensorFactory:
             "temperature": Temperature,
             "humidity": Humidity,
             "wind": Wind,
+            "illuminance": Illuminance,
         }
         if extended_state:
             object_list = list()

--- a/docs/howtoaddsensor.md
+++ b/docs/howtoaddsensor.md
@@ -1,0 +1,86 @@
+
+
+Integration for Blebox devices in Home Assistant.
+=============
+
+This documentation assumes you are familiar with Home Assistant and the Blebox devices.
+
+How to Add a New Sensor (Based on MultiSensor Illuminance)
+--------------------------------------------------------
+
+1. **Update SENSOR_TYPES tuple in homeassistant.components.blebox.sensor module to allow creation of proper homeassistant entities for light readings depending on device capability reported by blebox_uniapi library.**:
+
+
+   ```python
+   from homeassistant.components.blebox.sensor import SensorEntityDescription, SensorDeviceClass
+   from homeassistant.const import LIGHT_LUX
+
+   SENSOR_TYPES = (
+       # ... (existing entries)
+
+       SensorEntityDescription(
+           key="illuminance",
+           device_class=SensorDeviceClass.ILLUMINANCE,
+           native_unit_of_measurement=LIGHT_LUX,
+       ),
+   )```
+2. **Update box_types module in blebox_uniapi to support new sensor types. (API level will be given, use newest version of the sensor if u want to copy paste)**
+    ```python
+    "multiSensor": {
+        20220114: {
+            "api_path": "/state",
+            "extended_state_path": "/state/extended",
+            "sensors": [
+                [
+                    "multiSensor",
+                    {
+                        "illuminance": lambda x:f"multiSensor/sensors/[id={x}]/value",
+                        "temperature": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                        "wind": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                        "humidity": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                    },
+                ]
+            ],
+            "binary_sensors": [
+                [
+                    "multiSensor",
+                    {
+                        "rain": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                        "flood": lambda x: f"multiSensor/sensors/[id={x}]/value",
+                    },
+                ]
+            ],
+        },
+        ```
+3. **Create new sensor class in blebox_uniapi.sensor module for light related readings updating type_class_mapper in blebox_uniapi.sensor.SensorFactory to return proper sensor class if device supports light related measurements**
+
+    ```python
+    class Illuminance(BaseSensor):
+        def __init__(self, product: "Box", alias: str, methods: dict):
+            super().__init__(product, alias, methods)
+            self._unit = "lx"
+            self._device_class = "illuminance"
+
+        def _read_illuminance(self):
+            product = self._product
+            if product.last_data is not None:
+                raw = self.raw_value("illuminance")
+                if raw is not None:
+                    alias = self._alias
+                    return round(product.expect_int(alias, raw, 100000, 0)/100.0, 1)
+            return None
+    ```
+    ```python
+    class SensorFactory:
+        @classmethod
+        def many_from_config(
+            cls, product, box_type_config, extended_state
+        ) -> list["BaseSensor"]:
+            type_class_mapper = {
+                "airSensor": AirQuality,
+                "temperature": Temperature,
+                "humidity": Humidity,
+                "wind": Wind,
+                "illuminance" : Illuminance
+            }
+    ```


### PR DESCRIPTION
This commit adds support for integrating a multisensor with illuminance readings into Home Assistant using the blebox_uniapi library.

Changes Made:
1. Added a new entry for illuminance sensor in the SENSOR_TYPES tuple in homeassistant/components/blebox/sensor_types.py.
2. Updated the box_types configuration in blebox_uniapi/box_types.py to include support for the new illuminance sensor.
3. Created a new sensor class Illuminance in blebox_uniapi/sensor/sensor.py to handle light related readings.
4. Updated the SensorFactory in blebox_uniapi/sensor/sensor.py to include the new Illuminance sensor class.