### PR TITLE
fix: resolve regressions in cover and climate due to jmespath introduction

### DIFF
--- a/blebox_uniapi/climate.py
+++ b/blebox_uniapi/climate.py
@@ -1,5 +1,4 @@
 from .sensor import Temperature
-from .error import JPathFailed
 from typing import Optional, Any, Union
 from .feature import Feature
 from blebox_uniapi.jfollow import follow
@@ -141,10 +140,8 @@ class Climate(Temperature):
             self._max_temp = None
             return
 
-        try:
-            self.raw_value("minimum")
-        except JPathFailed:
-            # TODO: coverage
+        raw_min = self.raw_value("minimum")
+        if raw_min is None:
             return
 
         self._min_temp = self._read_temperature("minimum")

--- a/blebox_uniapi/cover.py
+++ b/blebox_uniapi/cover.py
@@ -1,6 +1,5 @@
 from enum import IntEnum, auto
 
-import blebox_uniapi.error
 from .error import MisconfiguredDevice
 from .feature import Feature
 from typing import TYPE_CHECKING, Any, Optional, Type, TypeVar

--- a/blebox_uniapi/cover.py
+++ b/blebox_uniapi/cover.py
@@ -222,11 +222,12 @@ class GateBox(Gate):
     def read_has_stop(self, alias: str, raw_value: Any, product: "Box") -> bool:
         if product.last_data is None:
             return False
-        try:
-            raw = raw_value("extraButtonType")
-        except blebox_uniapi.error.JPathFailed:
+
+        button_type = raw_value("extraButtonType")
+        if button_type is None:
             return False
-        return 1 == product.expect_int(alias, raw, 3, 0)
+
+        return button_type == 1
 
 
 class GateBoxB(GateBox):
@@ -269,6 +270,8 @@ class GateBoxB(GateBox):
     def close_command(self) -> str:
         if self._control_type == GateBoxControlType.OPEN_CLOSE:
             return "secondary"
+
+        return super().close_command
 
 
 GateT = TypeVar("GateT", bound=Gate)

--- a/blebox_uniapi/error.py
+++ b/blebox_uniapi/error.py
@@ -61,15 +61,6 @@ class UnsupportedAppVersion(BoxError):
 #     pass
 
 
-class JPathFailed(BoxError):
-    def __init__(self, message: str, path: str, data: Optional[dict]):
-        self._message = message
-        self._path = path
-        self._data = data
-
-    def __str__(self) -> str:
-        return f"{self._message} at '{self._path}' within '''{self._data}'''"
-
 
 class BadFieldExceedsMax(BoxError):
     def __init__(self, dev_name: str, field: str, value: int, max_value: int):

--- a/blebox_uniapi/error.py
+++ b/blebox_uniapi/error.py
@@ -1,6 +1,3 @@
-from typing import Optional
-
-
 class Error(RuntimeError):
     """Generic blebox_uniapi error."""
 


### PR DESCRIPTION
After introduction of jmespath the `JPathFailed` exception is never raised but there were two places that still relied on this exception. This PR fixes the issue.