### PR TITLE
feature: add support for active power sensors on switchbox/switchboxd devices

### DIFF
--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -280,7 +280,9 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                 [
                     "switchBox.energy",
                     {
+                        # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value",
+                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -305,7 +307,9 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                 [
                     "switchBox.energy",
                     {
+                        # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value",
+                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -330,7 +334,9 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                 [
                     "switchBox.energy",
                     {
+                        # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value",
+                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -357,7 +363,9 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                 [
                     "switchBox.energy",
                     {
+                        # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value ",
+                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -392,7 +400,9 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                 [
                     "switchBox.energy",
                     {
+                        # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value ",
+                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -424,7 +434,9 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                 [
                     "switchBox.energy",
                     {
+                        # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value ",
+                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -456,7 +468,9 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                 [
                     "switchBox.energy",
                     {
+                        # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value ",
+                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },

--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -282,7 +282,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     {
                         # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value",
-                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
+                        "activePower": lambda x: "sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -309,7 +309,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     {
                         # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value",
-                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
+                        "activePower": lambda x: "sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -336,7 +336,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     {
                         # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value",
-                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
+                        "activePower": lambda x: "sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -365,7 +365,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     {
                         # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value ",
-                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
+                        "activePower": lambda x: "sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -402,7 +402,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     {
                         # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value ",
-                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
+                        "activePower": lambda x: "sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -436,7 +436,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     {
                         # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value ",
-                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
+                        "activePower": lambda x: "sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },
@@ -470,7 +470,7 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     {
                         # note: switchbox/switchboxD sensors are currently not indexed (singletons)
                         "powerConsumption": lambda x: "powerMeasuring.powerConsumption[0]|value ",
-                        "activePower": lambda x: f"sensors[?type == 'activePower']|[0]|value",
+                        "activePower": lambda x: "sensors[?type == 'activePower']|[0]|value",
                         "periodS": "powerMeasuring.powerConsumption[0]|periodS",
                         "measurement_enabled": "powerMeasuring.enabled",
                     },

--- a/blebox_uniapi/sensor.py
+++ b/blebox_uniapi/sensor.py
@@ -35,7 +35,9 @@ class SensorFactory:
         # note: probably we should iterate extended state in future if there
         # are other api flavours other than multiSensor that provide sensors
         states = extended_state.get("multiSensor", {}).get("sensors", [])
-
+        # note: but for now we are only able to support non-multisensor devices
+        # that provide sensor data in extended data payload root
+        states.extend(extended_state.get("sensors", []))
         # note: power measuring feature predates multiSensor API, so we need a small
         # shim to adapt older shape of power measuring schema to the new sensor API
         if "powerMeasuring" in extended_state:


### PR DESCRIPTION
Switchbox/switchboxd devices suport both power consumption and active power sensing but due to oversight only power consumption sensor was mapped. This introduces proper wiring to activePower sensor via box_types manifest.

Thankfully the refactor done for multisensor/smartmeter pays off.  Adding missing sensor was mainly a matter of providing proper access routes. 