### PR TITLE
update airSensor definitions to latest api (20210118)

### DIFF
--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -72,6 +72,29 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     },
                 ]
             ],
+        },
+        20210118: {
+            "api_path": "/state",
+            "sensors": [
+                [
+                    "0.air",
+                    {
+                        "airQualityLevel": "air.airQualityLevel",
+                        "pm1.value": "air.sensors[?type == 'pm1']|[0]|value",
+                        "pm1.state": "air.sensors[?type == 'pm1']|[0]|state",
+                        "pm1.trend": "air.sensors[?type == 'pm1']|[0]|trend",
+                        "pm1.qualityLevel": "air.sensors[?type == 'pm1']|[0]|qualityLevel",
+                        "pm2_5.value": "air.sensors[?type == 'pm2.5']|[0]|value",
+                        "pm2_5.state": "air.sensors[?type == 'pm2.5']|[0]|state",
+                        "pm2_5.trend": "air.sensors[?type == 'pm2.5']|[0]|trend",
+                        "pm2_5.qualityLevel": "air.sensors[?type == 'pm2.5']|[0]|qualityLevel",
+                        "pm10.value": "air.sensors[?type == 'pm10']|[0]|value",
+                        "pm10.state": "air.sensors[?type == 'pm10']|[0]|state",
+                        "pm10.trend": "air.sensors[?type == 'pm10']|[0]|trend",
+                        "pm10.qualityLevel": "air.sensors[?type == 'pm10']|[0]|qualityLevel",
+                    },
+                ]
+            ],
         }
     },
     # dimmerBox

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -279,7 +279,7 @@ class TestTempSensor(DefaultBoxTest):
 class TestAirSensor(DefaultBoxTest):
     """Tests for sensors representing BleBox airSensor."""
 
-    DEV_INFO_PATH = "api/air/state"
+    DEV_INFO_PATH = "state"
 
     DEVCLASS = "sensors"
     ENTITY_CLASS = BleBoxSensorEntity
@@ -287,12 +287,13 @@ class TestAirSensor(DefaultBoxTest):
     DEVICE_INFO = json.loads(
         """
     {
-        "deviceName": "My air 1",
+        "deviceName": "airSensor",
         "type": "airSensor",
-        "fv": "0.973",
-        "hv": "0.6",
-        "apiLevel": "20180403",
-        "id": "1afe34db9437",
+        "product": "airSensor",
+        "fv": "0.1007",
+        "hv": "1.6",
+        "apiLevel": "20210118",
+        "id": "0af9e06b71d4",
         "ip": "192.168.1.11"
     }
     """
@@ -327,14 +328,15 @@ class TestAirSensor(DefaultBoxTest):
         """
         {
             "air": {
+                "airQualityLevel": 6,
                 "sensors": [
                     {
                         "type": "pm1",
                         "value": 49,
                         "trend": 3,
                         "state": 0,
-                        "qualityLevel": 0,
-                        "elaspedTimeS": -1
+                        "qualityLevel": -1,
+                        "elapsedTimeS": -1
                     },
                     {
                         "type": "pm2.5",
@@ -342,7 +344,7 @@ class TestAirSensor(DefaultBoxTest):
                         "trend": 1,
                         "state": 0,
                         "qualityLevel": 4,
-                        "elaspedTimeS": -1
+                        "elapsedTimeS": -1
                     },
                     {
                         "type": "pm10",
@@ -350,7 +352,7 @@ class TestAirSensor(DefaultBoxTest):
                         "trend": 0,
                         "state": 0,
                         "qualityLevel": 6,
-                        "elaspedTimeS": -1
+                        "elapsedTimeS": -1
                     }
                 ]
             }
@@ -358,8 +360,8 @@ class TestAirSensor(DefaultBoxTest):
         """
     )
 
-    # DEVICE_EXTENDED_INFO
-    # DEVICE_EXTENDED_INFO_PATH
+    DEVICE_EXTENDED_INFO = DEVICE_INFO
+    DEVICE_EXTENDED_INFO_PATH = 'info'
 
     async def test_init(self, aioclient_mock):
         """Test air quality sensor default state."""


### PR DESCRIPTION
Updates to latest api for airSensor (aliLevel: 20210118):
- new api endpoint (/state - /api/air/state is deprecated according to producent documentation)
- new summary field "airQualityLevel"
- extend with field "airQualityLevel" per internal sensor
- extend with field "trend" per internal sensor