### PR TITLE
feat: add is_position_inverted to expose position convention per devi…

### DIFF
--- a/blebox_uniapi/cover.py
+++ b/blebox_uniapi/cover.py
@@ -119,6 +119,11 @@ class Gate:
         return 0
 
     @property
+    def is_position_inverted(self) -> bool:
+        # shutterBox/gateController: % closed (0=open, 100=closed), inverted vs HA convention
+        return True
+
+    @property
     def is_slider(self) -> bool:
         return True
 
@@ -177,6 +182,11 @@ class GateBox(Gate):
     _control_type: Optional[GateBoxControlType]
 
     @property
+    def is_position_inverted(self) -> bool:
+        # gateBox: (0=closed, 100=open), matches HA convention
+        return False
+
+    @property
     def is_slider(self) -> bool:
         return False
 
@@ -189,8 +199,6 @@ class GateBox(Gate):
         return "primary"
 
     def read_state(self, alias: str, raw_value: Any, product: "Box") -> int:
-        # Reinterpret state to match shutterBox
-        # NOTE: shutterBox is inverted (0 == closed), gateBox isn't
         current = raw_value("position")
         desired = raw_value("desired")
 
@@ -328,6 +336,10 @@ class Cover(Feature):
     @property
     def has_tilt(self) -> bool:
         return self._attributes.has_tilt
+
+    @property
+    def is_position_inverted(self) -> bool:
+        return self._attributes.is_position_inverted
 
     @property
     def has_stop(self) -> bool:

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -242,6 +242,7 @@ class TestShutter(CoverTest):
 
         assert entity.supported_features & SUPPORT_SET_POSITION
         assert entity.current_cover_position is None
+        assert entity._feature.is_position_inverted is True
 
         # TODO: tilt
         # assert entity.supported_features & SUPPORT_SET_TILT_POSITION
@@ -385,6 +386,7 @@ class TestGateBox(CoverTest):
 
         assert not entity.supported_features & SUPPORT_SET_POSITION
         assert entity.current_cover_position is None
+        assert entity._feature.is_position_inverted is False
         self.assert_state(entity, None)
 
     async def test_device_info(self, aioclient_mock):
@@ -561,6 +563,7 @@ class TestGateBoxB(CoverTest):
         assert entity.supported_features & SUPPORT_OPEN
         assert entity.supported_features & SUPPORT_CLOSE
         assert entity.current_cover_position is None
+        assert entity._feature.is_position_inverted is False
         self.assert_state(entity, None)
 
     async def test_device_info(self, aioclient_mock):
@@ -693,6 +696,7 @@ class TestGateController(CoverTest):
 
         assert entity.supported_features & SUPPORT_SET_POSITION
         assert entity.current_cover_position is None
+        assert entity._feature.is_position_inverted is True
         self.assert_state(entity, None)
 
     async def test_device_info(self, aioclient_mock):


### PR DESCRIPTION
Add `is_position_inverted` property to cover classes to expose per-device position convention.

shutterBox and gateController report position as % closed (0=open, 100=closed), while gateBox uses 0=closed, 100=open convention. The HA integration currently inverts position unconditionally for all devices, which causes incorrect behavior for gateBox where buttons are incorrectly blocked at the maximum position. This property allows the integration to invert selectively based on the actual device convention.

After release and PR to HASS it'll fix the issue: https://github.com/blebox/blebox_uniapi/issues/177
