### PR TITLE
Ensure sensible_on_value returns list for MONO mode

### DIFF
--- a/blebox_uniapi/light.py
+++ b/blebox_uniapi/light.py
@@ -506,7 +506,7 @@ class Light(Feature):
                 if self.color_mode in (BleboxColorMode.RGBW, BleboxColorMode.RGBorW):
                     return 255, 255, 255, 255
                 if self.color_mode == BleboxColorMode.MONO:
-                    return 255
+                    return [255]
                 if self.color_mode in (BleboxColorMode.CT, BleboxColorMode.CTx2):
                     return 255, 255
             else:


### PR DESCRIPTION
Fix sensible_on_value returning int instead of list/tuple in MONO mode. The async_on method validates that on_value is either a list/tuple or matches off_value's type. For DacBoxD DC, off_value is a string, so the int failed validation and broke the "on" button in Home Assistant.