### PR TITLE
Fix restoring last color value correctly

### DIFF
--- a/blebox_uniapi/light.py
+++ b/blebox_uniapi/light.py
@@ -297,6 +297,12 @@ class Light(Feature):
         if brightness == 0:
             return [value]
 
+        if self.color_mode in (
+            BleboxColorMode.RGB,
+            BleboxColorMode.RGBW,
+            BleboxColorMode.RGBorW,
+        ):
+            value = self.normalise_elements_of_rgb(list(value))
         res = list(map(lambda x: round(x * (brightness / 255)), value))
         return res
 
@@ -310,10 +316,10 @@ class Light(Feature):
         :return: str
         """
         if self.mask:
-            if len(raw_hex) < len(self.mask("x").replace("x", "")):
-                return "0" * len(raw_hex)
-            else:
-                return "0" * (len(raw_hex) - len(self.mask("x").replace("x", "")))
+            placeholder = self._get_placeholder_for_color_mode()
+            mask_result = self.mask(placeholder)
+            x_count = mask_result.count("x")
+            return "0" * x_count
         elif raw_hex is not None:
             if len(raw_hex) < len(config["off"]):
                 return config["off"][: len(raw_hex)]
@@ -356,6 +362,18 @@ class Light(Feature):
         white_hex = value[6:8]
         return f"{rgb_hex}{white_hex}"
 
+    def _get_placeholder_for_color_mode(self) -> str:
+        if self._color_mode == BleboxColorMode.MONO:
+            return "xx"
+        elif self._color_mode in (BleboxColorMode.CT, BleboxColorMode.CTx2):
+            return "xxxx"
+        elif self._color_mode == BleboxColorMode.RGB:
+            return "xxxxxx"
+        elif self._color_mode in (BleboxColorMode.RGBW, BleboxColorMode.RGBorW):
+            return "xxxxxxxx"
+        else:
+            return "x"
+
     def return_color_temp_with_brightness(
         self, value, brightness: Any
     ) -> Optional[str]:
@@ -374,17 +392,8 @@ class Light(Feature):
         return self.rgb_hex_to_rgb_list(warm + cold)
 
     def value_for_selected_channels_from_given_val(self, value: str):
-        if self.color_mode in [BleboxColorMode.CT, BleboxColorMode.CTx2]:
-            lambda_result = self.mask("xxxx")
-        elif self.color_mode == BleboxColorMode.MONO:
-            lambda_result = self.mask("xx")
-        elif self.color_mode == BleboxColorMode.RGB:
-            lambda_result = self.mask("xxxxxx")
-        elif (
-            self.color_mode == BleboxColorMode.RGBW
-            or self.color_mode == BleboxColorMode.RGBorW
-        ):
-            lambda_result = self.mask("xxxxxxxx")
+        placeholder = self._get_placeholder_for_color_mode()
+        lambda_result = self.mask(placeholder)
         first_index = lambda_result.index("x")
         last_index = lambda_result.rindex("x")
         return value[first_index : last_index + 1]
@@ -451,10 +460,9 @@ class Light(Feature):
 
     def _set_last_on_value(self, alias, product, raw):
         if raw == self._off_value:
-            if (
-                product.type == "wLightBox"
-            ):  # jezeli urzadzenie typu wLightBox ma wyciagnac last_color
-                raw = product.expect_rgbw(alias, self.raw_value("last_color"))
+            last_color = self.raw_value("last_color")
+            if last_color is not None:
+                raw = product.expect_rgbw(alias, last_color)
                 if self.mask is not None:
                     raw = self.value_for_selected_channels_from_given_val(raw)
                     if raw == self._off_value:
@@ -518,7 +526,11 @@ class Light(Feature):
                 if self.color_mode in (BleboxColorMode.CT, BleboxColorMode.CTx2):
                     return 255, 255
             else:
-                if self.color_mode == BleboxColorMode.MONO:
+                if self.color_mode in (
+                    BleboxColorMode.MONO,
+                    BleboxColorMode.CT,
+                    BleboxColorMode.CTx2,
+                ):
                     return self.rgb_hex_to_rgb_list(self._last_on_state)
                 return self.normalise_elements_of_rgb(
                     self.rgb_hex_to_rgb_list(self._last_on_state)
@@ -529,9 +541,7 @@ class Light(Feature):
                     return [255] * len(self.rgb_hex_to_rgb_list(self._last_on_state))
                 else:
                     if self.color_mode == BleboxColorMode.RGB:
-                        return self.normalise_elements_of_rgb(
-                            self.rgb_hex_to_rgb_list(self._last_on_state[:6])
-                        )
+                        return self.rgb_hex_to_rgb_list(self._last_on_state[:6])
                     elif self.color_mode == BleboxColorMode.MONO:
                         return self._last_on_state
                     else:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1163,3 +1163,177 @@ class TestWLightBox(DefaultBoxTest):
 def test_unit_light_evaluate_brightness_from_rgb():
     tested_ob = Light.evaluate_brightness_from_rgb(iterable=(140, 230))
     assert tested_ob == 230
+
+
+def test_unit_light_evaluate_off_value_mono_2ch():
+    """Test evaluate_off_value for MONO mode with 2 channels (e.g., desired_color="0000")."""
+    from blebox_uniapi.box import Box
+    from unittest.mock import MagicMock
+
+    box = MagicMock(spec=Box)
+    box.type = "wLightBox"
+
+    def mask(x):
+        return f"{x}------"
+
+    light = Light(
+        product=box,
+        alias="test_mono1",
+        methods={},
+        extended_state={"rgbw": {"colorMode": 3}},
+        mask=mask,
+        desired_color="0000",
+        color_mode=3,
+        effect_list=None,
+        current_effect=None,
+    )
+
+    assert light._off_value == "00"
+
+
+def test_unit_light_evaluate_off_value_mono_4ch():
+    """Test evaluate_off_value for MONO mode with 4 channels (e.g., desired_color="00000000")."""
+    from blebox_uniapi.box import Box
+    from unittest.mock import MagicMock
+
+    box = MagicMock(spec=Box)
+    box.type = "wLightBox"
+
+    def mask(x):
+        return f"------{x}"
+
+    light = Light(
+        product=box,
+        alias="test_mono4",
+        methods={},
+        extended_state={"rgbw": {"colorMode": 3}},
+        mask=mask,
+        desired_color="00000000",
+        color_mode=3,
+        effect_list=None,
+        current_effect=None,
+    )
+
+    assert light._off_value == "00"
+
+
+def test_unit_light_evaluate_off_value_ct():
+    """Test evaluate_off_value for CT (color temperature) mode."""
+    from blebox_uniapi.box import Box
+    from unittest.mock import MagicMock
+
+    box = MagicMock(spec=Box)
+    box.type = "wLightBox"
+
+    def mask(x):
+        return f"{x}----"
+
+    light = Light(
+        product=box,
+        alias="test_cct",
+        methods={},
+        extended_state={"rgbw": {"colorMode": 5}},
+        mask=mask,
+        desired_color="ffff",
+        color_mode=5,
+        effect_list=None,
+        current_effect=None,
+    )
+
+    assert light._off_value == "0000"
+
+
+def test_unit_light_get_placeholder_for_color_mode():
+    """Test _get_placeholder_for_color_mode returns correct placeholder for each color mode."""
+    from blebox_uniapi.box import Box
+    from blebox_uniapi.light import BleboxColorMode
+    from unittest.mock import MagicMock
+
+    box = MagicMock(spec=Box)
+    box.type = "wLightBox"
+
+    def mask(x):
+        return x
+
+    test_cases = [
+        (BleboxColorMode.MONO, "xx"),
+        (BleboxColorMode.CT, "xxxx"),
+        (BleboxColorMode.CTx2, "xxxx"),
+        (BleboxColorMode.RGB, "xxxxxx"),
+        (BleboxColorMode.RGBW, "xxxxxxxx"),
+        (BleboxColorMode.RGBorW, "xxxxxxxx"),
+    ]
+
+    for color_mode, expected_placeholder in test_cases:
+        light = Light(
+            product=box,
+            alias=f"test_{color_mode}",
+            methods={},
+            extended_state={"rgbw": {"colorMode": color_mode}},
+            mask=mask,
+            desired_color="ff000000",
+            color_mode=color_mode,
+            effect_list=None,
+            current_effect=None,
+        )
+        assert light._get_placeholder_for_color_mode() == expected_placeholder
+
+
+def test_unit_light_set_last_on_value_with_last_color():
+    """Test _set_last_on_value calls expect_rgbw when last_color exists and raw is off."""
+    from blebox_uniapi.box import Box
+    from unittest.mock import MagicMock
+
+    box = MagicMock(spec=Box)
+    box.type = "wLightBox"
+    box.expect_rgbw = MagicMock(return_value="ff00ff00")
+    box.last_data = {"rgbw": {"lastOnColor": "ff00ff00"}}
+
+    def mask(x):
+        return x
+
+    light = Light(
+        product=box,
+        alias="test_last_color",
+        methods={"last_color": "rgbw.lastOnColor"},
+        extended_state={"rgbw": {"colorMode": 4, "lastOnColor": "ff00ff00"}},
+        mask=mask,
+        desired_color="00000000",
+        color_mode=4,
+        effect_list=None,
+        current_effect=None,
+    )
+
+    light._set_last_on_value("test_alias", box, light._off_value)
+    box.expect_rgbw.assert_called_once_with("test_alias", "ff00ff00")
+    assert light._last_on_state == "ff00ff00"
+
+
+def test_unit_light_set_last_on_value_without_last_color():
+    """Test _set_last_on_value uses default_on_value when last_color is None."""
+    from blebox_uniapi.box import Box
+    from unittest.mock import MagicMock
+
+    box = MagicMock(spec=Box)
+    box.type = "wLightBox"
+    box.expect_rgbw = MagicMock(return_value="ff00ff00")
+    box.last_data = {"rgbw": {}}
+
+    def mask(x):
+        return x
+
+    light = Light(
+        product=box,
+        alias="test_no_last_color",
+        methods={"last_color": "rgbw.lastOnColor"},
+        extended_state={"rgbw": {"colorMode": 4}},
+        mask=mask,
+        desired_color="00000000",
+        color_mode=4,
+        effect_list=None,
+        current_effect=None,
+    )
+
+    light._set_last_on_value("test_alias", box, light._off_value)
+    box.expect_rgbw.assert_not_called()
+    assert light._last_on_state == light._default_on_value


### PR DESCRIPTION
Fixed light devices (wLightBox API) not correctly restoring last color value across different color modes by correcting conditions in sensible_on_value() and _set_last_on_value() that were preventing proper value handling for RGB, CT, and MONO modes. 