### PR TITLE
Add temperature sensors to thermoBox

### DIFF
--- a/blebox_uniapi/box_types.py
+++ b/blebox_uniapi/box_types.py
@@ -194,6 +194,14 @@ BOX_TYPE_CONF: dict[str, dict[int, dict[str, Any]]] = {
                     },
                 ]
             ],
+            "sensors": [
+                [
+                    "temperature",
+                    {
+                        "temperature": lambda x: f"sensors[?id == `{x}`]|[0]|value",
+                    },
+                ]
+            ],
         }
     },
     # saunaBox


### PR DESCRIPTION
Added dedicated temperature sensors for thermoBox devices. Previously, only the current temperature value exposed through the climate platform was available, which did not represent the safety temperature readings. This change introduces additional sensor entities to expose those temperature values separately.